### PR TITLE
Added CLI file and script to setup.cfg.

### DIFF
--- a/assets/images/coverage.svg
+++ b/assets/images/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
-        <text x="80" y="14">71%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">66%</text>
+        <text x="80" y="14">66%</text>
     </g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [  #! Update me
 
 [tool.poetry.scripts]
 # Entry points for the package https://python-poetry.org/docs/pyproject/#scripts
-"wearipedia" = "wearipedia.__main__:app"
+"wearipedia" = "wearipedia.cl_parser:parse_CLI"
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 # https://github.com/terrencepreilly/darglint
 strictness = long
 docstring_style = google
+[options.entry_points]
+console_scripts =
+    wearipedia = wearipedia.cl_parser:parseCLI

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,4 @@ strictness = long
 docstring_style = google
 [options.entry_points]
 console_scripts =
-    wearipedia = wearipedia.cl_parser:parseCLI
+    wearipedia = wearipedia.cl_parser:parse_CLI

--- a/wearipedia/cl_parser.py
+++ b/wearipedia/cl_parser.py
@@ -5,12 +5,11 @@ import wearipedia
 
 
 # The rudimentary command line interface for wearipedia
-def parseCLI():
+def parse_CLI():
     desc = """Wearipedia is a tool for accessing and extracting data from 
     various wearable devices, such as devices from FitBit and Oura. This tool
     should be used by individuals monitoring their health, clinical researchers, 
-    health coaches, and biotech companies for development of new products. This is
-    not intended to be a data collection tool for marketing/advertisers. 
+    health coaches, and biotech companies for development of new products. 
 
     Currently for simple data extraction, one must specify the '--extract' flag with the specific device brand
     and model, the '--type' flag with the specific data type such as metrics, and the '--auth_creds' flag with
@@ -82,86 +81,75 @@ def parseCLI():
     # Convert parsed CL into dictionary
     args = vars(parser.parse_args())
 
-    # Formats start/end parameter to pass along data collection
-    def formatStartEnd(argDict: dict):
-        params = {}
-        start = argDict.get("params.start", "")
-        if start:
-            params["start"] = start
-        end = argDict.get("params.end", "")
-        if end:
-            params["end"] = end
-        return params
-
-    # Get the data based on what type of data is requested and if it is synthetic/real
-    def getData(argDict: dict, deviceObj, file=None):
-        # for replacing the default params inside the specific device child classes
-        paramDict = {}
-        if "params.start" in argDict and "params.end" in argDict:
-            paramDict = formatStartEnd(argDict)
-        data = deviceObj.get_data(argDict["type"], paramDict)
-        if file:
-            try:
-                file.write(data)
-            except:
-                print(
-                    "File failed to write synthetic output. Printing to console instead."
-                )
-                print(data)
-            finally:
-                file.close()
-
-    # Depending on the output flag, switch the outputs to either a file or STDOUT, returns validity of file
-    def checkOutput(file: str):
-        return file.lower().endswith((".json", ".txt"))
-
-    # Check device type and instantiate an object based on it
-    # If credentials are added, try them for a specific device instance, returns device instance
-    def createDeviceObject(argDict: dict, synthetic: bool):
-
-        # currently only supports Whoop4 and Garmin Fenix 7s devices
-        device = wearipedia.get_device(argDict["extract"])
-
-        if not device:
-            raise Exception("Not a valid device. Please try again.")
-
-        # check if credentials are present
-        if not synthetic:
-            with open(argDict["auth_creds"]) as json_file:
-                creds = json.load(json_file)
-                try:
-                    device.authenticate(creds["email"], creds["password"])
-                except:
-                    print(
-                        "Invalid credentials. Switching to synthetic data generation."
-                    )
-
-        # check if output file exists and is valid
-        if "output_path" in argDict:
-            outputFile = argDict["output_path"]
-            if checkOutput(outputFile):
-                try:
-                    f = open(outputFile, "w+")
-                    getData(argDict, device, f)
-                except:
-                    print("Output file failed to open.")
-            else:  # otherwise we just print output to STDOUT
-                getData(argDict, device)
-
-    # Switch case implementation for Python version compatibility
-    def switch(case: dict):
-        # go through each possible use case currently laid out
-        argKeys = sorted(case.keys())
-        # wearipedia --extract whoop/whoop_4 --type metrics --auth_creds path/to/creds.json
-        if all(key in argKeys for key in ("auth_creds", "extract", "type")):
-            createDeviceObject(case, False)
-        # wearipedia --extract whoop/whoop_4 --type metrics --synthetic
-        elif all(key in argKeys for key in ("extract", "synthetic", "type")):
-            createDeviceObject(case, True)
-        else:
-            raise Exception(
-                "The following arguments ", case, " are not valid use cases currently."
-            )
-
     # run the command line args into wearipedia tool
     switch(args)
+
+
+# Populates parameter dict to pass along data collection
+def get_params_dict(arg_dict: dict):
+    params = {}
+    for key in arg_dict:
+        if key.startswith("params."):
+            params[key[7:]] = arg_dict[key]
+    return params
+
+
+# Depending on the output flag, switch the outputs to either a file or STDOUT, returns validity of file
+def has_valid_extension(file: str):
+    try:
+        return file.lower().endswith((".json", ".txt"))
+    except:
+        print("Not a valid output file (must end in .json or .txt).")
+        return False
+
+
+# Check device type and instantiate an object based on it
+# If credentials are added, try them for a specific device instance, returns device instance
+def create_device_object(arg_dict: dict, synthetic: bool):
+
+    # currently only supports Whoop4 and Garmin Fenix 7s devices
+    device = wearipedia.get_device(arg_dict["extract"])
+
+    # check if credentials are present
+    if not synthetic:
+        try:
+            with open(arg_dict.get("auth_creds", "")) as json_file:
+                creds = json.load(json_file)
+                device.authenticate(creds["email"], creds["password"])
+        except Exception as e:
+            print(e, "\nInvalid credentials. Switching to synthetic data generation.")
+
+    # for replacing the default params inside the specific device child classes
+    params = get_params_dict(arg_dict)
+    data = device.get_data(arg_dict["type"], params=params)
+
+    # check if output file exists and is valid
+    print_to_console = True
+    if arg_dict["output_path"]:
+        output_file = arg_dict["output_path"]
+        if has_valid_extension(output_file):
+            try:
+                # Get the data based on what type of data is requested and if it is synthetic/real
+                with open(output_file, "w+") as f:
+                    f.write(data)
+                    print_to_console = False
+            except:
+                print("Output file failed to open. Printing results on screen.")
+    if print_to_console:  # otherwise we just print output to STDOUT
+        print(data)
+
+
+# Switch case implementation for Python version compatibility
+def switch(case: dict):
+    # go through each possible use case currently laid out
+    arg_keys = sorted(case.keys())
+    # wearipedia --extract whoop/whoop_4 --type metrics --auth_creds path/to/creds.json
+    if case["auth_creds"] and case["extract"] and case["type"]:
+        create_device_object(case, False)
+    # wearipedia --extract whoop/whoop_4 --type metrics --synthetic
+    elif case["extract"] and case["synthetic"] and case["type"]:
+        create_device_object(case, True)
+    else:
+        raise Exception(
+            "The following arguments ", case, " are not valid use cases currently."
+        )

--- a/wearipedia/cl_parser.py
+++ b/wearipedia/cl_parser.py
@@ -1,0 +1,167 @@
+import argparse
+import json
+
+import wearipedia
+
+
+# The rudimentary command line interface for wearipedia
+def parseCLI():
+    desc = """Wearipedia is a tool for accessing and extracting data from 
+    various wearable devices, such as devices from FitBit and Oura. This tool
+    should be used by individuals monitoring their health, clinical researchers, 
+    health coaches, and biotech companies for development of new products. This is
+    not intended to be a data collection tool for marketing/advertisers. 
+
+    Currently for simple data extraction, one must specify the '--extract' flag with the specific device brand
+    and model, the '--type' flag with the specific data type such as metrics, and the '--auth_creds' flag with
+    your credentials to access device data (otherwise synthetic data will be provided). 
+    
+    For more information about the current development and more detailed descriptions about the tool,
+    please visit the Github README page at https://github.com/Stanford-Health/wearipedia or visit our 
+    documentation website at https://wearipedia.readthedocs.io/.
+
+    Example for real data extraction: 
+    wearipedia --extract whoop/whoop_4 --type metrics --auth_creds path/to/creds.json
+
+    Example for synthetic data extraction: 
+    wearipedia --extract whoop/whoop_4 --type metrics --synthetic
+
+    """
+    # Create parser for CL
+    parser = argparse.ArgumentParser(prog="wearipedia", description=desc)
+
+    # Group synthetic data and real data authorizer as mutually exclusive
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-ac",
+        "--auth_creds",
+        type=str,
+        help="the textfile of authetication credentials for a specific device: -ac /FILENAME;",
+    )
+    group.add_argument(
+        "-s",
+        "--synthetic",
+        action="store_true",
+        help="generate synthetic data instead of real data (not compatible w/ --auth_creds);",
+    )
+
+    # The rest of the flags
+    parser.add_argument(
+        "-e",
+        "--extract",
+        type=str,
+        required=True,
+        help="the filepath to the notebook for the device and its model: -e /FILEPATH;",
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        type=str,
+        required=True,
+        help="the type of data to extracted: -t metric;",
+    )
+    parser.add_argument(
+        "-ps",
+        "--params.start",
+        type=str,
+        help="specify the start date of data collection as such: -ps YYYY-MM-DD;",
+    )
+    parser.add_argument(
+        "-pe",
+        "--params.end",
+        type=str,
+        help="specify the end date of data collection as such: -pe YYYY-MM-DD;",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_path",
+        type=str,
+        help="the output file for the data to stored into (only .txt and.json files): -o /FILENAME;",
+    )
+
+    # Convert parsed CL into dictionary
+    args = vars(parser.parse_args())
+
+    # Formats start/end parameter to pass along data collection
+    def formatStartEnd(argDict: dict):
+        params = {}
+        start = argDict.get("params.start", "")
+        if start:
+            params["start"] = start
+        end = argDict.get("params.end", "")
+        if end:
+            params["end"] = end
+        return params
+
+    # Get the data based on what type of data is requested and if it is synthetic/real
+    def getData(argDict: dict, deviceObj, file=None):
+        # for replacing the default params inside the specific device child classes
+        paramDict = {}
+        if "params.start" in argDict and "params.end" in argDict:
+            paramDict = formatStartEnd(argDict)
+        data = deviceObj.get_data(argDict["type"], paramDict)
+        if file:
+            try:
+                file.write(data)
+            except:
+                print(
+                    "File failed to write synthetic output. Printing to console instead."
+                )
+                print(data)
+            finally:
+                file.close()
+
+    # Depending on the output flag, switch the outputs to either a file or STDOUT, returns validity of file
+    def checkOutput(file: str):
+        return file.lower().endswith((".json", ".txt"))
+
+    # Check device type and instantiate an object based on it
+    # If credentials are added, try them for a specific device instance, returns device instance
+    def createDeviceObject(argDict: dict, synthetic: bool):
+
+        # currently only supports Whoop4 and Garmin Fenix 7s devices
+        device = wearipedia.get_device(argDict["extract"])
+
+        if not device:
+            raise Exception("Not a valid device. Please try again.")
+
+        # check if credentials are present
+        if not synthetic:
+            with open(argDict["auth_creds"]) as json_file:
+                creds = json.load(json_file)
+                try:
+                    device.authenticate(creds["email"], creds["password"])
+                except:
+                    print(
+                        "Invalid credentials. Switching to synthetic data generation."
+                    )
+
+        # check if output file exists and is valid
+        if "output_path" in argDict:
+            outputFile = argDict["output_path"]
+            if checkOutput(outputFile):
+                try:
+                    f = open(outputFile, "w+")
+                    getData(argDict, device, f)
+                except:
+                    print("Output file failed to open.")
+            else:  # otherwise we just print output to STDOUT
+                getData(argDict, device)
+
+    # Switch case implementation for Python version compatibility
+    def switch(case: dict):
+        # go through each possible use case currently laid out
+        argKeys = sorted(case.keys())
+        # wearipedia --extract whoop/whoop_4 --type metrics --auth_creds path/to/creds.json
+        if all(key in argKeys for key in ("auth_creds", "extract", "type")):
+            createDeviceObject(case, False)
+        # wearipedia --extract whoop/whoop_4 --type metrics --synthetic
+        elif all(key in argKeys for key in ("extract", "synthetic", "type")):
+            createDeviceObject(case, True)
+        else:
+            raise Exception(
+                "The following arguments ", case, " are not valid use cases currently."
+            )
+
+    # run the command line args into wearipedia tool
+    switch(args)


### PR DESCRIPTION
## Description
The main goal of this task was to build a command line tool for the Wearipedia project in order to streamline user experience in a simple interface. Thus, it eliminates the need to learn how to code, improving accessibility all around. The target of the CLI is to be able to run “pip install wearipedia” to install dependencies and then the newly installed CLI would be able to interpret user commands that begin with “wearipedia.” When building this tool in Python, I utilized the Python argparse library as the main framework for the CLI since it preserves industry standards in a CLI. I also needed to add scripts and entry points inside setup.cfg to trigger my parsing program. Finally, I needed to account for certain use cases which are of course, subject to change as more complexity is added to the Wearipedia project. In terms of coding these portions, it was straightforward to address what kinds of data a user wants, how they insert their login details, specifying time range parameters, etc using argparse. 

The most difficult part of this task was figuring out how to set up the script to auto-run my CLI changes inside the codebase. There was a lot of conflicting info online about scripting versus entry points for Python CLIs since there are many different ways to achieve the same goal. It became even more difficult when I discovered we were using Poetry to package everything which confused me further about how I should add changes to the already setup config files. However, thanks to Rodrigo, I was able to add scripts and entry points to setup.cfg which does not interfere with the Poetry setup inside of pyproject.toml.

## Related Issue

N/A
