### PR TITLE
Add detailed heart rate data to fitbit api

### DIFF
--- a/wearipedia/devices/fitbit/fitbit_sense.py
+++ b/wearipedia/devices/fitbit/fitbit_sense.py
@@ -20,7 +20,11 @@ class Fitbit_sense(BaseDevice):
     * `minutesFairlyActive`: number of minutes with fair activity
     * `distance`: in miles
     * `minutesSedentary`: number of minutes with no activity
-    * `heart_rate_day`: heart rate data
+    * `heart_rate_day`: heart rate summary over one day
+    * `heart_rate_day_detail_1sec`: heart rate data with granularity of 1 second
+    * `heart_rate_day_detail_1min`: heart rate data with granularity of 1 minute
+    * `heart_rate_day_detail_5min`: heart rate data with granularity of 5 minutes
+    * `heart_rate_day_detail_15min`: heart rate data with granularity of 15 minutes
     * `hrv`: heart rate variability data
     * `distance_day`: distance moved per day detailed by each minute
 
@@ -55,6 +59,10 @@ class Fitbit_sense(BaseDevice):
                 "distance",
                 "minutesSedentary",
                 "heart_rate_day",
+                "heart_rate_day_detail_1sec",
+                "heart_rate_day_detail_1min",
+                "heart_rate_day_detail_5min",
+                "heart_rate_day_detail_15min",
                 "hrv",
                 "distance_day",
             ],

--- a/wearipedia/devices/fitbit/fitbit_sense_fetch.py
+++ b/wearipedia/devices/fitbit/fitbit_sense_fetch.py
@@ -49,6 +49,18 @@ def fetch_real_data(data_type, access_token, start_date, end_date, single_date):
         "heart_rate_day": {
             "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1d.json"
         },
+        "heart_rate_day_detail_1sec": {
+            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1sec.json"
+        },
+        "heart_rate_day_detail_1min": {
+            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1min.json"
+        },
+        "heart_rate_day_detail_5min": {
+            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/5min.json"
+        },
+        "heart_rate_day_detail_15min": {
+            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/15min.json"
+        },
         "hrv": {"url": f"https://api.fitbit.com/1/user/-/hrv/date/{single_date}.json"},
         "distance_day": {
             "url": f"https://api.fitbit.com/1/user/-/activities/distance/date/{single_date}/1d.json"

--- a/wearipedia/devices/fitbit/fitbit_sense_fetch.py
+++ b/wearipedia/devices/fitbit/fitbit_sense_fetch.py
@@ -50,16 +50,16 @@ def fetch_real_data(data_type, access_token, start_date, end_date, single_date):
             "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1d.json"
         },
         "heart_rate_day_detail_1sec": {
-            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1sec.json"
+            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1d/1sec.json"
         },
         "heart_rate_day_detail_1min": {
-            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1min.json"
+            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1d/1min.json"
         },
         "heart_rate_day_detail_5min": {
-            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/5min.json"
+            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1d/5min.json"
         },
         "heart_rate_day_detail_15min": {
-            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/15min.json"
+            "url": f"https://api.fitbit.com/1/user/-/activities/heart/date/{single_date}/1d/15min.json"
         },
         "hrv": {"url": f"https://api.fitbit.com/1/user/-/hrv/date/{single_date}.json"},
         "distance_day": {


### PR DESCRIPTION
It seems like the intraday heart rate endpoints have changed since the fitbit API was developed. 

Added updated endpoints to allow fetching data at various levels of detail as per:
https://dev.fitbit.com/build/reference/web-api/intraday/get-heartrate-intraday-by-date/