### PR TITLE
Fix CI build after ubuntu-latest update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
 name: build
 
-on: 
+on:
   push:
   workflow_dispatch:
     inputs:
       git-ref:
-        description: Git Ref (Optional)    
+        description: Git Ref (Optional)
         required: false
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        python-version: ["3.9"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       run: poetry --version
 
     - name: Set up cache
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v3
       with:
         path: .venv
         key: venv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('poetry.lock') }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -3350,7 +3350,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version <= \"3.11\""
+markers = "(python_version != \"3.10\" or platform_system != \"Windows\" or platform_python_implementation == \"PyPy\") and python_version < \"3.11\""
 files = [
     {file = "numpy-1.24.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0bfb52d2169d58c1cdb8cc1f16989101639b34c7d3ce60ed70b19c63eba0b64"},
     {file = "numpy-1.24.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed094d4f0c177b1b8e7aa9cba7d6ceed51c0e569a5318ac0ca9a090680a6a1b1"},
@@ -3389,7 +3389,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
+markers = "python_version >= \"3.10\" and platform_system == \"Windows\" and platform_python_implementation != \"PyPy\" or python_version >= \"3.11\""
 files = [
     {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
     {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
@@ -4988,7 +4988,7 @@ description = "C version of reader, parser and emitter for ruamel.yaml derived f
 optional = false
 python-versions = ">=3.6"
 groups = ["dev"]
-markers = "platform_python_implementation == \"CPython\" and python_version < \"3.13\""
+markers = "platform_python_implementation == \"CPython\""
 files = [
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
@@ -5073,7 +5073,7 @@ description = "Fundamental algorithms for scientific computing in Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version <= \"3.11\""
+markers = "(python_version != \"3.10\" or platform_system != \"Windows\" or platform_python_implementation == \"PyPy\") and python_version < \"3.11\""
 files = [
     {file = "scipy-1.9.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1884b66a54887e21addf9c16fb588720a8309a57b2e258ae1c7986d4444d3bc0"},
     {file = "scipy-1.9.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:83b89e9586c62e787f5012e8475fbb12185bafb996a03257e9675cd73d3736dd"},
@@ -5113,7 +5113,7 @@ description = "Fundamental algorithms for scientific computing in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
+markers = "python_version >= \"3.10\" and platform_system == \"Windows\" and platform_python_implementation != \"PyPy\" or python_version >= \"3.11\""
 files = [
     {file = "scipy-1.15.2-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a2ec871edaa863e8213ea5df811cd600734f6400b4af272e1c011e69401218e9"},
     {file = "scipy-1.15.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:6f223753c6ea76983af380787611ae1291e3ceb23917393079dcc746ba60cfb5"},
@@ -6371,5 +6371,5 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9, <4.0"
-content-hash = "0dd57587de328b358f128a0c122704c094ea114d4db12ec4940dc0392d27331e"
+python-versions = ">=3.9, <3.13"
+content-hash = "d3e6b306ce7f56b86450fc054ca9041896d12de2d46441ffd868464373235ddd"

--- a/wearipedia/devices/google/googlefitness_fetch.py
+++ b/wearipedia/devices/google/googlefitness_fetch.py
@@ -16,6 +16,7 @@ def milliconvert(d):
         * 1000
     )
 
+
 def transform_response_bucket(data):
     """
     Convert response structure for real data: List[Dict] to List[List[Dict]]
@@ -42,7 +43,7 @@ def fetch_real_data(
 
     # Header that sends the Access Token in the GET request
     headers = {
-        "Authorization": "Bearer {}".format(g_access_token),
+        "Authorization": f"Bearer {g_access_token}",
         "Content-Type": "application/json;encoding=utf-8",
     }
 


### PR DESCRIPTION
This PR fixes some issues causing CI to fail at HEAD.

Fixes to build.yml:
* bump the python version to 3.9 since 3.8 isn't cached after ubuntu-latest was bumped to 24.04
* update actions/cache version to a supported version

Fix poetry lock and formatting issues at HEAD.

Note that after this PR, HEAD still seems to be failing tests with errors that may be real; this requires future investigation.
https://github.com/stefren/wearipedia/actions/runs/13850252602/job/38756238552#step:14:187