### PR TITLE
Upgrade tests to 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Since Garmin is no longer supported for 3.9, bumps tests to 3.10. Ideally we should support running 3.9 tests for other devices still until the EOL date.